### PR TITLE
add S3 VPC endpoints

### DIFF
--- a/src/curedcolumns/get_s3_parquet_schema.py
+++ b/src/curedcolumns/get_s3_parquet_schema.py
@@ -21,13 +21,23 @@ def get_s3_parquet_schema(session, bucket: str, key: Union[str, Path]) -> pyarro
     # Connect to AWS S3
     # https://arrow.apache.org/docs/python/filesystems.html#s3
     credentials = session.get_credentials()
+
+    # Get the VPC Endpoint dynamically from boto3
+    s3_client = session.client("s3")
+    endpoint_url = s3_client.meta.endpoint_url
+
     s3_file_system = pyarrow.fs.S3FileSystem(
         access_key=credentials.access_key,
         secret_key=credentials.secret_key,
         region=session.region_name,
-        session_token=credentials.token
+        session_token=credentials.token,
+        endpoint_override=endpoint_url
     )
 
+    # Build dataset location
+    key_str = str(key)
+    if not key_str.endswith("/"):
+        key_str += "/"
     # Build data set location
     path = f"{bucket}/{key}"
 

--- a/src/curedcolumns/get_s3_parquet_schema.py
+++ b/src/curedcolumns/get_s3_parquet_schema.py
@@ -38,7 +38,7 @@ def get_s3_parquet_schema(session, bucket: str, key: Union[str, Path]) -> pyarro
     key_str = str(key)
     if not key_str.endswith("/"):
         key_str += "/"
-    # Build data set location
+    
     path = f"{bucket}/{key}"
 
     # Use pyarrow to access the metadata


### PR DESCRIPTION
Jira ticket:[ Jira](https://uos-it-services.atlassian.net/browse/DATA-1152)

This PR fixes an AWS Error ACCESS_DENIED during HeadObject operation that occurs when running curedcolumns on infrastructure utilising private AWS VPC Endpoints.

Problem: the current implementation of curedcolumns.get_s3_parquet_schema initializes pyarrow.fs.S3FileSystem using only the access keys, secret keys, and region from the boto3 session. However, recent SDS changes require that we need to specify the end-point-url. Running the tool without the end-point-url flag results the following error:
```
curedcolumns --profile clean s3://curedplus-clean.store.rcc.shef.ac.uk --output OUTPUT_FILE --force
botocore.credentials:2026-06-09 15:04:00,548:INFO:Found credentials in shared credentials file: ~/.aws/credentials
botocore.configprovider:2026-06-09 15:04:00,688:INFO:Found endpoint for s3 via: environment_global.
curedcolumns.__main__:2026-06-09 15:04:00,694:INFO:Writing to 'OUTPUT_FILE'
curedcolumns.__main__:2026-06-09 15:04:00,966:INFO:Table: PC_Meds.PC_Meds
Traceback (most recent call last):
  File "/home/ubuntu/miniforge3/bin/curedcolumns", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ubuntu/miniforge3/lib/python3.12/site-packages/curedcolumns/__main__.py", line 124, in main
    schema = curedcolumns.get_s3_parquet_schema(bucket=args.bucket, key=key, session=session)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/miniforge3/lib/python3.12/site-packages/curedcolumns/get_s3_parquet_schema.py", line 36, in get_s3_parquet_schema
    data_set = pyarrow.parquet.ParquetDataset(path, filesystem=s3_file_system)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/miniforge3/lib/python3.12/site-packages/pyarrow/parquet/core.py", line 1315, in __init__
    finfo = filesystem.get_file_info(path_or_paths)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pyarrow/_fs.pyx", line 584, in pyarrow._fs.FileSystem.get_file_info
  File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
OSError: When getting information for key 'PC_Meds/PC_Meds/data' in bucket 'curedplus-clean.store.rcc.shef.ac.uk': AWS Error ACCESS_DENIED during HeadObject operation: No response body.
``` 
While boto3 automatically detects secure VPC endpoints (https://bucket.vpce-...) from the system environment or AWS config, PyArrow’s underlying C++ filesystem layer does not read these files automatically. Because the endpoint_override parameter was missing, PyArrow bypassed the secure network tunnel and attempted to route traffic through the public internet to Amazon's global S3 servers, resulting in a broken connection. Also, PyArrow treats S3 paths without a trailing slash (e.g., bucket/PC_Meds/PC_Meds/data) as a file instead of a directory prefix. This causes it to execute a HeadObject API call on the prefix string.

Changes: 
1- Updated get_s3_parquet_schema.py to extract the endpoint URL directly from the active boto3 session object and explicitly feed it into PyArrow.
2- To forces PyArrow to treat the path as a partitioned dataset directory rather than a singular file, I added a check to ensure directory paths passed to pyarrow.parquet.ParquetDataset consistently end with a trailing slash (/). 

Testing: For testing: After applying the changes, I ran (pip install -e .), then ran the command ``` curedcolumns --profile clean s3://curedplus-clean.store.rcc.shef.ac.uk --output OUTPUT_FILE --force ```

The output in the OUTPUT_FILE  was as expected.
